### PR TITLE
Update Compose UI to 1.3.0-beta01

### DIFF
--- a/buildSrc/src/main/kotlin/com/skydoves/orbital/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/orbital/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
   internal const val KOTLIN_GRADLE_DOKKA = "1.7.10"
   internal const val KOTLIN_BINARY_VALIDATOR = "0.11.0"
 
-  internal const val COMPOSE = "1.3.0-alpha03"
+  internal const val COMPOSE = "1.3.0-beta01"
   internal const val COMPOSE_COMPILER = "1.3.0"
   internal const val COROUTINES = "1.6.4"
 
@@ -21,7 +21,7 @@ object Versions {
   internal const val COMPOSE_ACTIVITY = "1.4.0"
   internal const val COMPOSE_CONSTRAINT = "1.0.0"
 
-  internal const val LANDSCAPIST_GLIDE = "1.6.0"
+  internal const val LANDSCAPIST_GLIDE = "1.6.1"
 
   internal const val ANDROIDX_TEST_VERSION = "1.4.0"
   internal const val BASE_PROFILE_VERSION = "1.2.0-rc01"


### PR DESCRIPTION
## Guidelines
Update Compose UI to `1.3.0-beta01`.